### PR TITLE
Fixes warnings emitted by clang compiler.

### DIFF
--- a/stub/cbits/stub.cpp
+++ b/stub/cbits/stub.cpp
@@ -9,6 +9,7 @@
 #include <sys/un.h>
 #include <arpa/inet.h>
 
+
 #include <thread>
 #include <functional>
 
@@ -147,7 +148,7 @@ class Response {
         { }
 
     ~Response() {
-        delete this->buf;
+        delete[] this->buf;
     }
 
     template<typename T>
@@ -467,6 +468,7 @@ static int handle_command(Socket& sock, const char *buf, uint32_t cmd_len) {
       default:
         return 1;
     }
+    return 0;
 }
 
 /* return non-zero on error */


### PR DESCRIPTION
Clang emited few warnings during build, so this commit fixes them.
```
bits/stub.cpp:151:9: error:
     warning: 'delete' applied to a pointer that was allocated with 'new[]'; did you mean 'delete[]'? [-Wmismatched-new-delete]
            delete this->buf;
            ^
                  []
    |
151 |         delete this->buf;
```

```
cbits/stub.cpp:471:1: error:
     warning: control may reach end of non-void function [-Wreturn-type]
    |
471 | }
    | ^
}
```