### PR TITLE
Small cabal file fixes.

### DIFF
--- a/stub/ghc-debug-stub.cabal
+++ b/stub/ghc-debug-stub.cabal
@@ -1,9 +1,10 @@
+cabal-version:       2.1
 name:                ghc-debug-stub
 version:             0.1.0.0
 -- synopsis:
 -- description:
 homepage:            https://github.com/bgamari/ghc-debug
-license:             BSD3
+license:             BSD-3-Clause
 license-file:        LICENSE
 author:              Ben Gamari
 maintainer:          ben@smart-cactus.org
@@ -11,7 +12,6 @@ copyright:           (c) 2019 Ben Gamari
 category:            Development
 build-type:          Simple
 extra-source-files:  CHANGELOG.md
-cabal-version:       >=1.10
 
 flag trace
   Description: Enable tracing
@@ -23,11 +23,12 @@ library
   hs-source-dirs:      src
   build-depends:       base >=4.12 && <4.14, ghc-prim
   default-language:    Haskell2010
-  c-sources:           cbits/stub.cpp, cbits/socket.cpp
-  ghc-options: -threaded
+  cxx-sources:         cbits/stub.cpp, cbits/socket.cpp
+  cxx-options:         -std=gnu++11
+  ghc-options:         -threaded
   extra-libraries:     stdc++
   if flag(trace)
-    C-Options: -DTRACE
+    cpp-options: -DTRACE
 
 executable debug-test
   main-is:             Test.hs


### PR DESCRIPTION
Pass cxx flags that allows building ghc-debug-stub on macOS.