### PR TITLE
Fix simple-shell.nix

### DIFF
--- a/simple-shell.nix
+++ b/simple-shell.nix
@@ -28,5 +28,6 @@ in
                                np.cabal-install
                                np.zlib
                                np.elfutils
+                               np.git
                               ];
               }

--- a/simple-shell.nix
+++ b/simple-shell.nix
@@ -15,12 +15,18 @@ let
     sha256 = "1qz1lwk0j2r6jzpc5ssrlfcf1193ay5l23kwyda5wld5sm170ffw";
   }) { pkgs = np; }).mkGhc;
 
+  # This archive will be gone on 20th May. Please update when a new build of the
+  # `wip/ghc-debug` branch becomes available (which will hold for another month).
   ghc = mkGhc
-        { url = "https://gitlab.haskell.org/ghc/ghc/-/jobs/150213/artifacts/raw/ghc-x86_64-fedora27-linux.tar.xz";
-          hash = "02ympcnm33msdl4kv10nb1s44vc9mrsrgwgylis3l8ncr1564igy"; };
+        { url = "https://gitlab.haskell.org/ghc/ghc/-/jobs/312946/artifacts/raw/ghc-x86_64-fedora27-linux.tar.xz";
+          hash = "1gw3q6g059yz0lqd9x3r23isghdwqw5zimysm73pp26jdg3rsc2w";
+        };
 
 in
   _np.mkShell { buildInputs = [ ghc
                                np.ncurses
                                np.cabal-install
-                             ]; }
+                               np.zlib
+                               np.elfutils
+                              ];
+              }

--- a/simple-shell.nix
+++ b/simple-shell.nix
@@ -4,8 +4,8 @@ let
   np = import (_np.fetchFromGitHub {
     owner  = "NixOS";
     repo   = "nixpkgs";
-    rev    = "541d9cce8af7a490fb9085305939569567cb58e6";
-    sha256 = "0jgz72hhzkd5vyq5v69vpljjlnf0lqaz7fh327bvb3cvmwbfxrja";
+    rev    = "6d445f8398d2d585d20d9acacf00fd9d15081b3b";
+    sha256 = "1ajd0zr31iny3g9hp0pc1y2pxcm3nakdv6260lnvyn0k4vygync2";
   }) {};
 
   mkGhc = (import (np.fetchFromGitHub {
@@ -30,4 +30,8 @@ in
                                np.elfutils
                                np.git
                               ];
+
+                # Export the location of the SSL CA bundle
+                SSL_CERT_FILE = "${np.cacert}/etc/ssl/certs/ca-bundle.crt";
+                NIX_SSL_CERT_FILE = "${np.cacert}/etc/ssl/certs/ca-bundle.crt";
               }


### PR DESCRIPTION
This creates a build environment that can compile (`cabal new-build --enable-tests`) the project.

Unfortunately the system tests currently do not terminate. As I've got the same issue with my locally built GHC, I think it's not due to this nix script.